### PR TITLE
Fixed the CSS for 'empty task' bar and updated styles on 'edit task' page

### DIFF
--- a/app/assets/stylesheets/assignments_widget.scss
+++ b/app/assets/stylesheets/assignments_widget.scss
@@ -221,45 +221,24 @@
                         .hidden-task {
                             display: none;
                         }
-                        .empty-task-wrapper {
-                            //this class help fix the margin issue for empty task
-                            flex: 1 0 180px !important;
-                            height: 62.07px;
-                            .empty-task {
-                                height: 60px;
-                                border: 1.5px dashed $gray;
-                                margin-right: 10px;
-                                margin-left: 10px;
-                                .task-title {
-                                    color: $darkgray;
-                                    h5 {
-                                        white-space: nowrap;
-                                        width: 150px;
-                                        overflow: hidden;
-                                        text-overflow: ellipsis;
-                                    }
-                                    p {
-                                        white-space: nowrap;
-                                        width: 150px;
-                                        overflow: hidden;
-                                        text-overflow: ellipsis;
-                                    }
-                                    a {
-                                        color: $darkgray;
-                                    }
-                                }
-                                .task-selection-github a {
-                                    color: $darkgray !important;
-                                }
+                        .empty-task {
+                            text-align: center;
+                            flex: 1 0 180px;
+                            width: 180px;
+                            vertical-align: top;
+                            height: 60px;
+                            border: 1.5px dashed $gray;
+                            margin-right: 5px;
+                            margin-left: 5px;
+                            i {
+                                margin-top: 25px;
+                                color: $gray;
+                            }
+                            &:hover {
+                                border: 1.5px dashed $darkgray;
+                                cursor: pointer;
                                 i {
-                                    color: $gray;
-                                }
-                                &:hover {
-                                    border: 1.5px dashed $darkgray;
-                                    cursor: pointer;
-                                    i {
-                                        color: $darkgray;
-                                    }
+                                    color: $darkgray;
                                 }
                             }
                         }

--- a/app/assets/stylesheets/assignments_widget.scss
+++ b/app/assets/stylesheets/assignments_widget.scss
@@ -231,7 +231,7 @@
                             margin-right: 5px;
                             margin-left: 5px;
                             i {
-                                margin-top: 25px;
+                                margin-top: 24px;
                                 color: $gray;
                             }
                             &:hover {

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -9,7 +9,7 @@
         padding: 30px 0px;
         border-bottom: 1px solid #F0F0F0;
         label {
-            width: 80px;
+            width: 100px;
             margin-right: 40px;
         }
         input {
@@ -18,9 +18,9 @@
             height: 28px;
             border-radius: 3px !important;
             outline: none;
-            color: #BFBFBF;
+            color: black;
             box-shadow: none;
-            width: 600px;
+            width: 785px;
         }
         textarea {
             border: 1px solid #E2E2E2;
@@ -28,11 +28,11 @@
             height: 28px;
             border-radius: 3px !important;
             outline: none;
-            color: #BFBFBF;
+            color: black;
             box-shadow: none;
             display: block;
             float: left;
-            width: 600px;
+            width: 785px;
             height: 103px;
         }
         .details {
@@ -61,7 +61,7 @@
             width: 40px;
         }
     }
-    .colm-right {
+    .colm {
         margin: 0px 25px;
         flex: 1 1 100%;
         display: flex;
@@ -80,25 +80,9 @@
             button {
                 width: 90px;
             }
-            flex: 1 0 80px;
+            flex: 0 0 90px;
             label {
-                width: 80px;
-                margin-right: 40px;
-            }
-        }
-    }
-    .colm-left {
-        margin: 0px 25px;
-        flex: 1 1 100%;
-        display: flex;
-        flex-direction: column;
-        .colm-section {
-            button {
-                width: 90px;
-            }
-            flex: 1 0 80px;
-            label {
-                width: 80px;
+                width: 100px;
                 margin-right: 40px;
             }
         }

--- a/app/views/site/overview.html.erb
+++ b/app/views/site/overview.html.erb
@@ -74,10 +74,8 @@
                                     <div class="task assigned-task hidden-task">
                                         <!-- This is required for sorting developers with empty tasks -->
                                     </div>
-                                    <div class="task empty-task flex-row_center" data-toggle="modal" data-target="#add_task">
-                                        <div class="flex-auto text-center">
-                                            <i class="fa fa-plus add-user_icon" aria-hidden="true" data-toggle="modal" data-target="#add_task"></i>
-                                        </div>
+                                    <div class="task empty-task" data-toggle="modal" data-target="#add_task">
+                                        <i class="fa fa-plus add-user_icon" aria-hidden="true"></i>
                                     </div>
                                     <!-- End add new task -->
                     </div>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -23,79 +23,80 @@
     </form>
 </div>
 <div class="info-container">
-    <!-- left column section -->
-<div class="colm-left">
-    <div class="colm-section">
-        <label>Assign to</label>
-        <div class="btn-group">
-            <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+
+    <div class="colm">
+        <div class="colm-section">
+            <label>Assign to</label>
+            <div class="btn-group">
+                <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     None <span class="caret"></span>
   </button>
-            <ul class="dropdown-menu">
-                <li><a>haha</a></li>
-                <li><a>haha</a></li>
-                <li><a>haha</a></li>
-            </ul>
+                <ul class="dropdown-menu">
+                    <li><a>haha</a></li>
+                    <li><a>haha</a></li>
+                    <li><a>haha</a></li>
+                </ul>
+            </div>
         </div>
-    </div>
-    <!-- selectors -->
-    <div class="colm-section">
-        <label>Diffculties</label>
-        <div class="selector">
-            <input value="0" min="0" max="5" class="range-slider-range" type="range" style="flex: 0 1 80%;">
-            <span class="range-slider-value">0</span>
-        </div>
-    </div>
-    <div class="colm-section">
-        <label>Priority</label>
-        <div class="selector">
-            <input value="0" min="0" max="5" class="range-slider-range" type="range" style="flex: 0 1 80%;">
-            <span class="range-slider-value">0</span>
-        </div>
-    </div>
-    <!-- selector ends -->
-</div>
-<!-- left column section ends -->
-<!-- right column section -->
-<div class="colm-right ">
-    <!-- time requested -->
-    <div class="colm-section">
-        <label>Time Requested</label>
-        <div class="btn-group">
-            <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <div class="colm-section">
+            <label>Time Requested</label>
+            <div class="btn-group">
+                <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
    None <span class="caret"></span>
   </button>
-            <ul class="dropdown-menu">
-                <li><a>1 Month</a></li>
-                <li><a>2 Month</a></li>
-                <li><a>haha</a></li>
-            </ul>
+                <ul class="dropdown-menu">
+                    <li><a>1 Month</a></li>
+                    <li><a>2 Month</a></li>
+                    <li><a>haha</a></li>
+                </ul>
+            </div>
         </div>
-    </div>
-    <!-- time requested ends -->
-    <!-- points section -->
-    <div class="colm-section points">
-        <label>Points</label>
-        <div class="btn-group" role="group" aria-label="Third group">
-            <button type="button" class="btn btn-default">1</button>
-            <button type="button" class="btn btn-default">2</button>
-            <button type="button" class="btn btn-default">3</button>
-            <button type="button" class="btn btn-default">4</button>
-            <button type="button" class="btn btn-default">5</button>
-        </div>
-    </div>
-    <!-- points section ends -->
-    <!-- set date -->
-    <div class="colm-section date">
-        <label>Due Date</label>
-        <div class="btn-group date-nav" role="group" aria-label="..." style="">
-            <button type="button" class="btn btn-default" data-nav="yesterday"><i class="fa fa-chevron-left" aria-hidden="true"></i></button>
+        <div class="colm-section date">
+            <label>Due Date</label>
+            <div class="btn-group date-nav" role="group" aria-label="..." style="">
+                <button type="button" class="btn btn-default" data-nav="yesterday"><i class="fa fa-chevron-left" aria-hidden="true"></i></button>
 
-            <input class="btn btn-default date-picker">
+                <input class="btn btn-default date-picker">
 
-            <button type="button" class="btn btn-default" data-nav="tomorrow"><i class="fa fa-chevron-right" aria-hidden="true"></i></button>
+                <button type="button" class="btn btn-default" data-nav="tomorrow"><i class="fa fa-chevron-right" aria-hidden="true"></i></button>
+            </div>
+        </div>
+        <div>
+            <button type="button" class="btn btn-default">UPDATE</button>
+            <button type="button" class="btn btn-default">CANCEL</button>
+        </div>
+
+
+    </div>
+
+
+    <div class="colm">
+        <div class="colm-section">
+            <label>Diffculties</label>
+            <div class="selector">
+                <input value="0" min="0" max="5" class="range-slider-range" type="range" style="flex: 0 1 80%;">
+                <span class="range-slider-value">0</span>
+            </div>
+        </div>
+        <div class="colm-section">
+            <label>Priority</label>
+            <div class="selector">
+                <input value="0" min="0" max="5" class="range-slider-range" type="range" style="flex: 0 1 80%;">
+                <span class="range-slider-value">0</span>
+            </div>
+        </div>
+
+        <div class="colm-section points">
+            <label>Points</label>
+            <div class="btn-group" role="group" aria-label="Third group">
+                <button type="button" class="btn btn-default">1</button>
+                <button type="button" class="btn btn-default">2</button>
+                <button type="button" class="btn btn-default">3</button>
+                <button type="button" class="btn btn-default">4</button>
+                <button type="button" class="btn btn-default">5</button>
+            </div>
         </div>
     </div>
-    <!-- set date ends -->
 </div>
-<!-- right column section ends-->
+
+-->


### PR DESCRIPTION
-fixed 'empty task' bar's CSS by adding width and centering the 'plus icon'.
-added 'update' and 'cancel' buttons for  'edit task' page.
-moving priority and difficulties 'selectors' to upper right in 'edit task' page
